### PR TITLE
privacy: add title and description to privacy policy pages

### DIFF
--- a/src/pages/bingebuddy/privacy-policy/index.md
+++ b/src/pages/bingebuddy/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: BingeBuddy Privacy Policy
+description: Privacy policy for the BingeBuddy iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/cocktail-craft/privacy-policy/index.md
+++ b/src/pages/cocktail-craft/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: Cocktail Craft Privacy Policy
+description: Privacy policy for the Cocktail Craft iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/gcs/privacy-policy/index.md
+++ b/src/pages/gcs/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: GCS Privacy Policy
+description: Privacy policy for the GCS iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/habittrace/privacy-policy/index.md
+++ b/src/pages/habittrace/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: HabitTrace Privacy Policy
+description: Privacy policy for the HabitTrace iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/health-sync/privacy-policy/index.md
+++ b/src/pages/health-sync/privacy-policy/index.md
@@ -4,8 +4,6 @@ title: Health Sync Privacy Policy
 description: Privacy policy for the Health Sync iOS app.
 ---
 
-# Privacy Policy
-
 _Last updated: 1 August 2026_
 
 ## General

--- a/src/pages/jotified/privacy-policy/index.md
+++ b/src/pages/jotified/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: Jotified Privacy Policy
+description: Privacy policy for the Jotified iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/knitting-folio/privacy-policy/index.md
+++ b/src/pages/knitting-folio/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: KnittingFolio Privacy Policy
+description: Privacy policy for the KnittingFolio iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/mockupmagic/privacy-policy/index.md
+++ b/src/pages/mockupmagic/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: Mockup Magic Privacy Policy
+description: Privacy policy for the Mockup Magic iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/puzzly/privacy-policy/index.md
+++ b/src/pages/puzzly/privacy-policy/index.md
@@ -4,8 +4,6 @@ title: Puzzly Privacy Policy
 description: Privacy policy for the Puzzly iOS app.
 ---
 
-# Privacy Policy
-
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data.
 No personal information, usage data or any other information is collected — nothing.

--- a/src/pages/sunlight-tracker/privacy-policy/index.md
+++ b/src/pages/sunlight-tracker/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: Sunlight Tracker Privacy Policy
+description: Privacy policy for the Sunlight Tracker iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/sygeplejetools/privacy-policy/index.md
+++ b/src/pages/sygeplejetools/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: Sygeplejetools Privacy Policy
+description: Privacy policy for the Sygeplejetools iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 Except for data collected by Apple, such as when you have enabled Share with Developers, I do not collect any data. 

--- a/src/pages/veil/privacy-policy/index.md
+++ b/src/pages/veil/privacy-policy/index.md
@@ -1,8 +1,8 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
+title: Veil Privacy Policy
+description: Privacy policy for the Veil iOS app.
 ---
-
-# Privacy Policy
 
 ## General
 


### PR DESCRIPTION
Ten of the twelve privacy-policy pages had only `layout:` in their frontmatter. AboutLayout renders `{frontmatter.title}` into <title>, the meta description and an <h1>, so those pages shipped as:

    <title> • nikolajjsj</title>
    <meta name="description">
    <h1 class="..."></h1>

These are the URLs the App Store listings point at, so they were the worst-placed instance of the bug.

Add `title` and `description` to all ten, matching the convention already used by health-sync and puzzly.

Also drop the `# Privacy Policy` heading from the markdown body of all twelve pages. The layout already renders the title as an <h1>, so it was a second <h1> on every page — including health-sync and puzzly, which had the duplicate even before this change.