### PR TITLE
theme: stop pinning the theme on first visit

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -23,24 +23,12 @@
 </button>
 
 <script is:inline>
-  const theme = (() => {
-    if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
-      return localStorage.getItem("theme") ?? "light";
-    }
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-      return "dark";
-    }
-    return "light";
-  })();
-
-  if (theme === "light") {
-    document.documentElement.classList.remove("dark");
-  } else {
-    document.documentElement.classList.add("dark");
-  }
-
-  window.localStorage.setItem("theme", theme);
-
+  // The theme is already applied by the inline script in Layout.astro, which
+  // runs before first paint. Nothing here may write to localStorage on load:
+  // storing a value is what marks the theme as *chosen*, and only pressing
+  // the button counts as choosing. Otherwise the first visit would silently
+  // pin whatever the OS happened to prefer at that moment, and the site would
+  // ignore `prefers-color-scheme` from then on.
   const handleToggleClick = () => {
     const element = document.documentElement;
     element.classList.toggle("dark");
@@ -52,4 +40,13 @@
   document
     .getElementById("themeToggle")
     ?.addEventListener("click", handleToggleClick);
+
+  // With no explicit choice stored, follow the OS if it changes while the
+  // page is open.
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", (event) => {
+      if (localStorage.getItem("theme")) return;
+      document.documentElement.classList.toggle("dark", event.matches);
+    });
 </script>


### PR DESCRIPTION
ThemeToggle's inline script ran `localStorage.setItem("theme", theme)` unconditionally on every page load. On a first visit with no stored preference it resolved the theme from `prefers-color-scheme` and then wrote that down — so an implicit default became an explicit choice.

From then on the site ignored the OS setting permanently: a visitor who later switched their system to dark mode never saw dark mode again, short of finding the toggle or clearing site data.

Storing a value is what marks the theme as *chosen*, so only pressing the button may write. Drop the write, and with it the theme resolution and class application that duplicated Layout.astro's head script — that one runs before first paint and is the copy that matters. This leaves ThemeToggle responsible only for the button.

Also follow the OS live when nothing is stored, which is the point of not pinning: a `prefers-color-scheme` change now updates an open page unless the visitor has made an explicit choice.